### PR TITLE
QSP-14

### DIFF
--- a/contracts/OmnuumCAManager.sol
+++ b/contracts/OmnuumCAManager.sol
@@ -16,7 +16,7 @@ contract OmnuumCAManager is OwnableUpgradeable {
     }
 
     /// @notice (omnuum contract address => (bytes32 topic => hasRole))
-    mapping(address => mapping(bytes32 => bool)) public roles;
+    mapping(address => mapping(string => bool)) public roles;
 
     /// @notice (omnuum contract address => (topic, active))
     mapping(address => Contract) public contracts;
@@ -25,9 +25,9 @@ contract OmnuumCAManager is OwnableUpgradeable {
     mapping(string => address) public indexedContracts;
 
     // actionType: register, remove
-    event Updated(address indexed contractAccount, Contract, string indexed actionType);
-    event RoleAdded(address ca, string role);
-    event RoleRemoved(address ca, string role);
+    event Updated(address indexed contractAccount, Contract, string actionType);
+    event RoleAdded(address indexed ca, string role);
+    event RoleRemoved(address indexed ca, string role);
 
     function initialize() public initializer {
         __Ownable_init();
@@ -44,9 +44,8 @@ contract OmnuumCAManager is OwnableUpgradeable {
             require(_CAs[i].isContract(), 'AE2');
         }
 
-        bytes32 role = keccak256(abi.encodePacked(_role));
         for (uint256 i = 0; i < len; i++) {
-            roles[_CAs[i]][role] = true;
+            roles[_CAs[i]][_role] = true;
             emit RoleAdded(_CAs[i], _role);
         }
     }
@@ -56,9 +55,8 @@ contract OmnuumCAManager is OwnableUpgradeable {
     /// @param _role role name to be removed
     function removeRole(address[] calldata _CAs, string calldata _role) external onlyOwner {
         uint256 len = _CAs.length;
-        bytes32 role = keccak256(abi.encodePacked(_role));
         for (uint256 i = 0; i < len; i++) {
-            roles[_CAs[i]][role] = false;
+            roles[_CAs[i]][_role] = false;
             emit RoleRemoved(_CAs[i], _role);
         }
     }
@@ -68,7 +66,7 @@ contract OmnuumCAManager is OwnableUpgradeable {
     /// @param _role role name to be checked with
     /// @return whether target address has specified role or not
     function hasRole(address _target, string calldata _role) external view returns (bool) {
-        return roles[_target][keccak256(abi.encodePacked(_role))];
+        return roles[_target][_role];
     }
 
     /// @notice Register multiple addresses at once

--- a/contracts/OmnuumNFT1155.sol
+++ b/contracts/OmnuumNFT1155.sol
@@ -30,7 +30,7 @@ contract OmnuumNFT1155 is ERC1155Upgradeable, ReentrancyGuardUpgradeable, Ownabl
     bool public isRevealed;
     string private coverUri;
 
-    event Uri(address indexed nftContract, string indexed uri);
+    event Uri(address indexed nftContract, string uri);
     event ReceiveFee(uint256 amount);
 
     /// @notice constructor function for upgradeable

--- a/contracts/OmnuumWallet.sol
+++ b/contracts/OmnuumWallet.sol
@@ -77,7 +77,7 @@ contract OmnuumWallet {
     /* *****************************************************************************
      *   Events
      * *****************************************************************************/
-    event PaymentReceived(address indexed sender, bytes32 indexed topic, string description);
+    event PaymentReceived(address indexed sender, string topic, string description);
     event EtherReceived(address indexed sender);
     event Requested(address indexed owner, uint256 indexed requestId, RequestTypes indexed requestType);
     event Approved(address indexed owner, uint256 indexed requestId, OwnerVotes votes);
@@ -164,7 +164,7 @@ contract OmnuumWallet {
      *   Methods - Public, External
      * *****************************************************************************/
 
-    function makePayment(bytes32 _topic, string calldata _description) external payable {
+    function makePayment(string calldata _topic, string calldata _description) external payable {
         /// @custom:error (NE3) - A zero payment is not acceptable
         require(msg.value > 0, 'NE3');
         emit PaymentReceived(msg.sender, _topic, _description);

--- a/test/caManager.test.js
+++ b/test/caManager.test.js
@@ -177,8 +177,6 @@ describe('OmnuumCAManager', () => {
 
       await tx.wait();
 
-      console.log(await omnuumCAManager.hasRole(mockNFT.address, Constants.contractRole.exchange));
-
       // true case
       expect(await omnuumCAManager.hasRole(mockNFT.address, Constants.contractRole.exchange)).to.be.equal(true);
 


### PR DESCRIPTION
Remove use of hash and replace them by string
For ease of use, we decide to use string at the expense of gas optimization.
