### PR TITLE
refactor:Ownable initialize msg.sender to tx.origin

### DIFF
--- a/contracts/V1/OmnuumNFT1155.sol
+++ b/contracts/V1/OmnuumNFT1155.sol
@@ -63,8 +63,6 @@ contract OmnuumNFT1155 is ERC1155Upgradeable, ReentrancyGuardUpgradeable, Ownabl
         caManager = OmnuumCAManager(_caManagerAddress);
         mintManager = OmnuumMintManager(caManager.getContract('MINTMANAGER'));
         coverUri = _coverUri;
-
-        transferOwnership(_prjOwner);
     }
 
     /// @dev send fee to omnuum wallet

--- a/contracts/utils/OwnableUpgradeable.sol
+++ b/contracts/utils/OwnableUpgradeable.sol
@@ -17,7 +17,7 @@ contract OwnableUpgradeable is Initializable, ContextUpgradeable {
     }
 
     function __Ownable_init_unchained() internal onlyInitializing {
-        _transferOwnership(_msgSender());
+        _transferOwnership(tx.origin);
     }
 
     /**


### PR DESCRIPTION
msg.sender => tx.origin @OwnableUpgradeable to designate the owner as the nft project owner when the nft beacon proxy is deployed at once.
